### PR TITLE
Unbreak manpage installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ if (${INSTALL_EXAMPLE_SCRIPTS})
 endif()
 
 if (${INSTALL_DOCUMENTATION})
+    include(GNUInstallDirs) # CMAKE_INSTALL_MANDIR
     install_scdoc_man_page(wl-mirror 1)
     if (${INSTALL_EXAMPLE_SCRIPTS})
         install_scdoc_man_page(wl-present 1)


### PR DESCRIPTION
`CMAKE_INSTALL_BINDIR` is not affected due to [hardcoded fallback](https://github.com/Kitware/CMake/blob/v3.23.2/Source/cmInstallCommand.cxx#L2262) using relative rather than absolute path.