### PR TITLE
README: Update packaging information for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The [`scripts/`](scripts/) folder contains examples on how `wl-mirror` can be us
 `wl-mirror` is already packaged in many distros and can be installed via the
 package manager:
 
-- Arch Linux AUR: `yay -S wl-mirror` or `yay -S wl-mirror-git`
+- Arch Linux: `pacman -S wl-mirror`
 - Fedora: `dnf install wl-mirror`
 - Ubuntu: .deb file download in [releases](https://github.com/Ferdi265/wl-mirror/releases/latest/), official package in progress
 - Debian: .deb file download in [releases](https://github.com/Ferdi265/wl-mirror/releases/latest/), official package in progress


### PR DESCRIPTION
Provide information on how to install wl-mirror on Arch Linux from the official repositories using `pacman`.