### PR TITLE
src/stream: initialize timeout

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -164,6 +164,7 @@ void init_stream(ctx_t * ctx) {
     ctx->stream.event_handler.on_event = on_stream_data;
     ctx->stream.event_handler.on_each = NULL;
     ctx->stream.event_handler.next = NULL;
+    ctx->stream.event_handler.timeout_ms = -1;
 
     if (ctx->opt.stream) {
         int flags = fcntl(STDIN_FILENO, F_GETFL, 0);


### PR DESCRIPTION
Currently, the stream option consumes quite some CPU. The reason is that timeout_ms is initialized as 0 implicitely. Make sure it is -1 so that all the necessary logic kicks in (mininum search, defaults).

Indeed, for me -S consumes one full core after some time (whether via wl-present or directly with wl-mirror). I haven't seen that usage with the patch any more.

In other news: Thanks for this great tool :-)