### PR TITLE
Allow cross-compiling

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -18,9 +18,11 @@ pkg_check_modules(WaylandClient REQUIRED IMPORTED_TARGET "wayland-client")
 pkg_check_modules(WaylandEGL REQUIRED IMPORTED_TARGET "wayland-egl")
 pkg_check_modules(EGL REQUIRED IMPORTED_TARGET "egl")
 pkg_check_modules(GLESv2 REQUIRED IMPORTED_TARGET "glesv2")
+if(NOT DEFINED WAYLAND_SCANNER)
 pkg_check_modules(WaylandScanner REQUIRED "wayland-scanner")
 pkg_get_variable(WAYLAND_SCANNER "wayland-scanner" "wayland_scanner")
 set(WAYLAND_SCANNER "${WAYLAND_SCANNER}" PARENT_SCOPE)
+endif()
 
 # man dependencies
 if (${INSTALL_DOCUMENTATION})


### PR DESCRIPTION
Make it possible to set WAYLAND_SCANNER in the cmake command line. This allows using a native build of the wayland-scanner executable under the Yocto project, and allows building wl-mirrors in this cross-compiler environment.