### PR TITLE
Fix stream input handling

### DIFF
--- a/include/wlm/stream.h
+++ b/include/wlm/stream.h
@@ -9,10 +9,12 @@
 struct ctx;
 
 typedef struct ctx_stream {
+    // lifetime: written in stream::on_stream_data, overwritten at the end of the function
     char * line;
     size_t line_len;
     size_t line_cap;
 
+    // lifetime: written in stream::on_line, overwritten at the end of the function
     char ** args;
     size_t args_len;
     size_t args_cap;

--- a/include/wlm/stream.h
+++ b/include/wlm/stream.h
@@ -9,7 +9,12 @@
 struct ctx;
 
 typedef struct ctx_stream {
-    // lifetime: written in stream::on_stream_data, overwritten at the end of the function
+    // lifetime: written in stream::on_stream_data.
+    // All full lines are overwritten at the end of the function.
+    // Trailing bytes which are not newline-terminated are treated as part of a line
+    // which was not read fully.
+    // These bytes are moved to the beginning of the buffer
+    // in order to continue reading the line once more data becomes available.
     char * line;
     size_t line_len;
     size_t line_cap;

--- a/include/wlm/stream.h
+++ b/include/wlm/stream.h
@@ -9,17 +9,23 @@
 struct ctx;
 
 typedef struct ctx_stream {
-    // lifetime: written in stream::on_stream_data.
-    // All full lines are overwritten at the end of the function.
-    // Trailing bytes which are not newline-terminated are treated as part of a line
-    // which was not read fully.
-    // These bytes are moved to the beginning of the buffer
-    // in order to continue reading the line once more data becomes available.
+    // holds stream input lines prior to being parsed as options
+    // holds partial line lines between calls to stream::on_stream_data()
+    //
+    // ownership:
+    // - resized in stream::line_reserve()
+    // - written in stream::on_stream_data()
+    // - written in stream::on_line() (passed line partially overwritten)
     char * line;
     size_t line_len;
     size_t line_cap;
 
-    // lifetime: written in stream::on_line, overwritten at the end of the function
+    // holds parsed argv array that will be parsed as options
+    // empty between calls to stream::on_line()
+    //
+    // ownership:
+    // - resized in stream::args_push()
+    // - written in stream::on_line()
     char ** args;
     size_t args_len;
     size_t args_cap;


### PR DESCRIPTION
- Handle multiple newline-separated commands read in the same invocation of stream::on_stream_data.
- Fix memory safety issues:
    - Initialize newly allocated memory to zero.
    - Ensure that buffer for data from stdin is always \0-terminated.
- Limit lifetime of input data to functions handling the input. This keeps the input buffer size from increasing beyond the largest one-time input size (plus the linear overhead from the way allocations are increased).