### PR TITLE
WIP: Reworked Target System and Toplevel Capture

### DIFF
--- a/include/wlm/egl.h
+++ b/include/wlm/egl.h
@@ -12,7 +12,7 @@
 struct ctx;
 
 #define MAX_PLANES 4
-typedef struct dmabuf {
+typedef struct wlm_dmabuf {
     uint32_t width;
     uint32_t height;
     uint32_t drm_format;
@@ -22,18 +22,18 @@ typedef struct dmabuf {
     uint32_t * offsets;
     uint32_t * strides;
     uint64_t modifier;
-} dmabuf_t;
+} wlm_dmabuf_t;
 
 typedef struct {
     uint32_t drm_format;
     size_t num_modifiers;
     uint64_t * modifiers;
-} dmabuf_format_t;
+} wlm_dmabuf_format_t;
 
 typedef struct {
     size_t num_formats;
-    dmabuf_format_t * formats;
-} dmabuf_formats_t;
+    wlm_dmabuf_format_t * formats;
+} wlm_dmabuf_formats_t;
 
 typedef struct ctx_egl {
     EGLDisplay display;
@@ -48,7 +48,7 @@ typedef struct ctx_egl {
     PFNEGLQUERYDMABUFMODIFIERSEXTPROC eglQueryDmaBufModifiersEXT;
 
     // supported dmabuf formats
-    dmabuf_formats_t dmabuf_formats;
+    wlm_dmabuf_formats_t dmabuf_formats;
 
     // texture size
     uint32_t width;

--- a/include/wlm/egl/dmabuf.h
+++ b/include/wlm/egl/dmabuf.h
@@ -9,6 +9,6 @@
 typedef struct ctx ctx_t;
 typedef struct wlm_egl_format wlm_egl_format_t;
 
-bool wlm_egl_dmabuf_import(ctx_t * ctx, dmabuf_t * dmabuf, const wlm_egl_format_t * format, bool invert_y, bool region_aware);
+bool wlm_egl_dmabuf_import(ctx_t * ctx, wlm_dmabuf_t * dmabuf, const wlm_egl_format_t * format, bool invert_y, bool region_aware);
 
 #endif

--- a/include/wlm/event.h
+++ b/include/wlm/event.h
@@ -7,18 +7,18 @@
 
 struct ctx;
 
-typedef struct event_handler {
-    struct event_handler * next;
+typedef struct wlm_event_loop_handler {
+    struct wlm_event_loop_handler * next;
     int fd;
     int events;
     int timeout_ms;
     void (*on_event)(struct ctx * ctx, uint32_t events);
     void (*on_each)(struct ctx * ctx);
-} event_handler_t;
+} wlm_event_loop_handler_t;
 
 typedef struct ctx_event {
     int pollfd;
-    event_handler_t * handlers;
+    wlm_event_loop_handler_t * handlers;
 
     bool initialized;
 } ctx_event_t;
@@ -26,9 +26,9 @@ typedef struct ctx_event {
 void wlm_event_init(struct ctx * ctx);
 void wlm_event_cleanup(struct ctx * ctx);
 
-void wlm_event_add_fd(struct ctx * ctx, event_handler_t * handler);
-void wlm_event_change_fd(struct ctx * ctx, event_handler_t * handler);
-void wlm_event_remove_fd(struct ctx * ctx, event_handler_t * handler);
+void wlm_event_add_fd(struct ctx * ctx, wlm_event_loop_handler_t * handler);
+void wlm_event_change_fd(struct ctx * ctx, wlm_event_loop_handler_t * handler);
+void wlm_event_remove_fd(struct ctx * ctx, wlm_event_loop_handler_t * handler);
 void wlm_event_loop(struct ctx * ctx);
 
 #endif

--- a/include/wlm/mirror.h
+++ b/include/wlm/mirror.h
@@ -11,10 +11,10 @@
 #include <wlm/mirror/target.h>
 
 struct ctx;
-struct output_list_node;
+struct wlm_wayland_output_entry;
 
-typedef struct fallback_backend fallback_backend_t;
-struct fallback_backend {
+typedef struct wlm_fallback_backend wlm_fallback_backend_t;
+struct wlm_fallback_backend {
     char * name;
     void (*init)(struct ctx * ctx);
 };
@@ -26,8 +26,8 @@ typedef struct ctx_mirror {
     bool invert_y;
 
     // backend data
-    mirror_backend_t * backend;
-    fallback_backend_t * fallback_backends;
+    wlm_mirror_backend_t * backend;
+    wlm_fallback_backend_t * fallback_backends;
     size_t auto_backend_index;
 
     // state flags
@@ -37,7 +37,7 @@ typedef struct ctx_mirror {
 void wlm_mirror_init(struct ctx * ctx);
 void wlm_mirror_backend_init(struct ctx * ctx);
 
-void wlm_mirror_output_removed(struct ctx * ctx, struct output_list_node * node);
+void wlm_mirror_output_removed(struct ctx * ctx, struct wlm_wayland_output_entry * node);
 void wlm_mirror_update_title(struct ctx * ctx);
 void wlm_mirror_options_updated(struct ctx * ctx);
 

--- a/include/wlm/mirror.h
+++ b/include/wlm/mirror.h
@@ -8,6 +8,7 @@
 #include <EGL/egl.h>
 #include <wlm/transform.h>
 #include <wlm/mirror/backends.h>
+#include <wlm/mirror/target.h>
 
 struct ctx;
 struct output_list_node;
@@ -19,7 +20,7 @@ struct fallback_backend {
 };
 
 typedef struct ctx_mirror {
-    struct output_list_node * current_target;
+    wlm_mirror_target_t * current_target;
     struct wl_callback * frame_callback;
     region_t current_region;
     bool invert_y;

--- a/include/wlm/mirror/backends.h
+++ b/include/wlm/mirror/backends.h
@@ -7,12 +7,12 @@ struct ctx;
 
 #define MIRROR_BACKEND_FATAL_FAILCOUNT 10
 
-typedef struct mirror_backend {
+typedef struct wlm_mirror_backend {
     void (*do_capture)(struct ctx * ctx);
     void (*do_cleanup)(struct ctx * ctx);
     void (*on_options_updated)(struct ctx * ctx);
     size_t fail_count;
-} mirror_backend_t;
+} wlm_mirror_backend_t;
 
 void wlm_mirror_export_dmabuf_init(struct ctx * ctx);
 void wlm_mirror_screencopy_shm_init(struct ctx * ctx);

--- a/include/wlm/mirror/export-dmabuf.h
+++ b/include/wlm/mirror/export-dmabuf.h
@@ -15,7 +15,7 @@ typedef enum {
 } dmabuf_state_t;
 
 typedef struct {
-    mirror_backend_t header;
+    wlm_mirror_backend_t header;
 
     // dmabuf frame object
     struct zwlr_export_dmabuf_frame_v1 * dmabuf_frame;
@@ -25,7 +25,7 @@ typedef struct {
     uint32_t y;
     uint32_t buffer_flags;
     uint32_t frame_flags;
-    dmabuf_t dmabuf;
+    wlm_dmabuf_t dmabuf;
 
     // dmabuf state flags
     dmabuf_state_t state;

--- a/include/wlm/mirror/extcopy.h
+++ b/include/wlm/mirror/extcopy.h
@@ -16,7 +16,7 @@ typedef enum {
 } extcopy_state_t;
 
 typedef struct {
-    mirror_backend_t header;
+    wlm_mirror_backend_t header;
     bool use_dmabuf;
 
     struct ext_image_copy_capture_session_v1 * capture_session;

--- a/include/wlm/mirror/extcopy.h
+++ b/include/wlm/mirror/extcopy.h
@@ -19,7 +19,6 @@ typedef struct {
     mirror_backend_t header;
     bool use_dmabuf;
 
-    struct ext_image_capture_source_v1 * capture_source;
     struct ext_image_copy_capture_session_v1 * capture_session;
     struct ext_image_copy_capture_frame_v1 * capture_frame;
 

--- a/include/wlm/mirror/screencopy.h
+++ b/include/wlm/mirror/screencopy.h
@@ -18,7 +18,7 @@ typedef enum {
 } screencopy_state_t;
 
 typedef struct {
-    mirror_backend_t header;
+    wlm_mirror_backend_t header;
     bool use_dmabuf;
 
     // screencopy frame object

--- a/include/wlm/mirror/target.h
+++ b/include/wlm/mirror/target.h
@@ -20,7 +20,7 @@ typedef struct {
 
 typedef struct {
     wlm_mirror_target_t header;
-    output_list_node_t * output;
+    wlm_wayland_output_entry_t * output;
 } wlm_mirror_target_output_t;
 
 typedef struct {
@@ -33,9 +33,9 @@ wlm_mirror_target_t * wlm_mirror_target_find_output(ctx_t * ctx, const char * na
 wlm_mirror_target_t * wlm_mirror_target_find_toplevel(ctx_t * ctx, const char * identifier);
 
 // TODO: remove this
-wlm_mirror_target_t * wlm_mirror_target_create_output(ctx_t * ctx, output_list_node_t * output_node);
+wlm_mirror_target_t * wlm_mirror_target_create_output(ctx_t * ctx, wlm_wayland_output_entry_t * output_node);
 
-output_list_node_t * wlm_mirror_target_get_output_node(wlm_mirror_target_t * target);
+wlm_wayland_output_entry_t * wlm_mirror_target_get_output_node(wlm_mirror_target_t * target);
 struct ext_image_capture_source_v1 * wlm_mirror_target_get_capture_source(wlm_mirror_target_t * target);
 enum wl_output_transform wlm_mirror_target_get_transform(wlm_mirror_target_t * target);
 

--- a/include/wlm/mirror/target.h
+++ b/include/wlm/mirror/target.h
@@ -1,0 +1,44 @@
+#ifndef WLM_MIRROR_TARGET_H_
+#define WLM_MIRROR_TARGET_H_
+
+#include <wayland-client-protocol.h>
+#include <wlm/wayland.h>
+
+typedef struct ctx ctx_t;
+
+typedef enum {
+    WLM_MIRROR_TARGET_TYPE_NULL = 0,
+    WLM_MIRROR_TARGET_TYPE_OUTPUT,
+    WLM_MIRROR_TARGET_TYPE_TOPLEVEL,
+} wlm_mirror_target_type_t;
+
+typedef struct {
+    wlm_mirror_target_type_t type;
+    struct ext_image_capture_source_v1 * source;
+    enum wl_output_transform transform;
+} wlm_mirror_target_t;
+
+typedef struct {
+    wlm_mirror_target_t header;
+    output_list_node_t * output;
+} wlm_mirror_target_output_t;
+
+typedef struct {
+    wlm_mirror_target_t header;
+    struct ext_foreign_toplevel_handle_v1 * toplevel;
+} wlm_mirror_target_toplevel_t;
+
+wlm_mirror_target_t * wlm_mirror_target_parse(ctx_t * ctx, const char * target);
+wlm_mirror_target_t * wlm_mirror_target_find_output(ctx_t * ctx, const char * name);
+wlm_mirror_target_t * wlm_mirror_target_find_toplevel(ctx_t * ctx, const char * identifier);
+
+// TODO: remove this
+wlm_mirror_target_t * wlm_mirror_target_create_output(ctx_t * ctx, output_list_node_t * output_node);
+
+output_list_node_t * wlm_mirror_target_get_output_node(wlm_mirror_target_t * target);
+struct ext_image_capture_source_v1 * wlm_mirror_target_get_capture_source(wlm_mirror_target_t * target);
+enum wl_output_transform wlm_mirror_target_get_transform(wlm_mirror_target_t * target);
+
+void wlm_mirror_target_destroy(wlm_mirror_target_t * target);
+
+#endif

--- a/include/wlm/options.h
+++ b/include/wlm/options.h
@@ -6,7 +6,7 @@
 #include <wlm/transform.h>
 
 struct ctx;
-struct output_list_node;
+struct wlm_wayland_output_entry;
 
 typedef enum {
     SCALE_FIT,
@@ -55,7 +55,7 @@ bool wlm_opt_parse_scaling(scale_t * scaling, scale_filter_t * scaling_filter, c
 bool wlm_opt_parse_backend(backend_t * backend, const char * backend_arg);
 bool wlm_opt_parse_transform(transform_t * transform, const char * transform_arg);
 bool wlm_opt_parse_region(region_t * region, char ** output, const char * region_arg);
-bool wlm_opt_find_output(struct ctx * ctx, struct output_list_node ** output_handle, region_t * region_handle);
+bool wlm_opt_find_output(struct ctx * ctx, struct wlm_wayland_output_entry ** output_handle, region_t * region_handle);
 
 void wlm_opt_usage(struct ctx * ctx);
 void wlm_opt_version(struct ctx * ctx);

--- a/include/wlm/stream.h
+++ b/include/wlm/stream.h
@@ -30,7 +30,7 @@ typedef struct ctx_stream {
     size_t args_len;
     size_t args_cap;
 
-    event_handler_t event_handler;
+    wlm_event_loop_handler_t event_handler;
     bool initialized;
 } ctx_stream_t;
 

--- a/include/wlm/wayland.h
+++ b/include/wlm/wayland.h
@@ -12,6 +12,7 @@
 #include <wlm/proto/wlr-screencopy-unstable-v1.h>
 #include <wlm/proto/ext-image-copy-capture-v1.h>
 #include <wlm/proto/ext-image-capture-source-v1.h>
+#include <wlm/proto/ext-foreign-toplevel-list-v1.h>
 #include <wlm/proto/linux-dmabuf-unstable-v1.h>
 #include <wlm/wayland/shm.h>
 #include <wlm/wayland/dmabuf.h>
@@ -26,6 +27,9 @@ typedef struct output_list_node {
     struct output_list_node * next;
     struct ctx * ctx;
     char * name;
+    char * make;
+    char * model;
+    char * description;
     struct wl_output * output;
     struct zxdg_output_v1 * xdg_output;
     uint32_t output_id;
@@ -129,6 +133,7 @@ void wlm_wayland_window_set_title(struct ctx * ctx, const char * title);
 void wlm_wayland_window_set_fullscreen(struct ctx * ctx);
 void wlm_wayland_window_unset_fullscreen(struct ctx * ctx);
 void wlm_wayland_window_update_scale(struct ctx * ctx, double scale, bool is_fractional);
+bool wlm_wayland_find_output(ctx_t * ctx, const char * output_name, output_list_node_t ** output);
 void wlm_wayland_cleanup(struct ctx * ctx);
 
 #endif

--- a/include/wlm/wayland.h
+++ b/include/wlm/wayland.h
@@ -23,8 +23,8 @@
 
 struct ctx;
 
-typedef struct output_list_node {
-    struct output_list_node * next;
+typedef struct wlm_wayland_output_entry {
+    struct wlm_wayland_output_entry * next;
     struct ctx * ctx;
     char * name;
     char * make;
@@ -39,14 +39,14 @@ typedef struct output_list_node {
     int32_t height;
     int32_t scale;
     enum wl_output_transform transform;
-} output_list_node_t;
+} wlm_wayland_output_entry_t;
 
-typedef struct seat_list_node {
-    struct seat_list_node * next;
+typedef struct wlm_wayland_seat_entry {
+    struct wlm_wayland_seat_entry * next;
     struct ctx * ctx;
     struct wl_seat * seat;
     uint32_t seat_id;
-} seat_list_node_t;
+} wlm_wayland_seat_entry_t;
 
 typedef struct ctx_wl {
     ctx_wl_shm_t shmbuf;
@@ -91,8 +91,8 @@ typedef struct ctx_wl {
     uint32_t toplevel_capture_source_manager_id;
 
     // output list
-    output_list_node_t * outputs;
-    seat_list_node_t * seats;
+    wlm_wayland_output_entry_t * outputs;
+    wlm_wayland_seat_entry_t * seats;
 
     // surface objects
     struct wl_surface * surface;
@@ -107,13 +107,13 @@ typedef struct ctx_wl {
 #endif
 
     // buffer size
-    output_list_node_t * current_output;
+    wlm_wayland_output_entry_t * current_output;
     uint32_t width;
     uint32_t height;
     double scale;
 
     // event handler
-    event_handler_t event_handler;
+    wlm_event_loop_handler_t event_handler;
 
     // state flags
     uint32_t last_surface_serial;
@@ -133,7 +133,7 @@ void wlm_wayland_window_set_title(struct ctx * ctx, const char * title);
 void wlm_wayland_window_set_fullscreen(struct ctx * ctx);
 void wlm_wayland_window_unset_fullscreen(struct ctx * ctx);
 void wlm_wayland_window_update_scale(struct ctx * ctx, double scale, bool is_fractional);
-bool wlm_wayland_find_output(ctx_t * ctx, const char * output_name, output_list_node_t ** output);
+bool wlm_wayland_find_output(ctx_t * ctx, const char * output_name, wlm_wayland_output_entry_t ** output);
 void wlm_wayland_cleanup(struct ctx * ctx);
 
 #endif

--- a/include/wlm/wayland/dmabuf.h
+++ b/include/wlm/wayland/dmabuf.h
@@ -29,7 +29,7 @@ typedef struct ctx_wl_dmabuf {
     struct zwp_linux_dmabuf_feedback_v1 * feedback;
     struct zwp_linux_buffer_params_v1 * buffer_params;
     struct wl_buffer * buffer;
-    dmabuf_t raw_buffer;
+    wlm_dmabuf_t raw_buffer;
 
     bool initialized;
 } ctx_wl_dmabuf_t;
@@ -66,6 +66,6 @@ void wlm_wayland_dmabuf_dealloc(ctx_t * ctx);
 struct wl_buffer * wlm_wayland_dmabuf_get_buffer(ctx_t * ctx);
 
 /// Get the dmabuf_t object for the DMA-BUF
-dmabuf_t * wlm_wayland_dmabuf_get_raw_buffer(ctx_t * ctx);
+wlm_dmabuf_t * wlm_wayland_dmabuf_get_raw_buffer(ctx_t * ctx);
 
 #endif

--- a/src/egl.c
+++ b/src/egl.c
@@ -306,7 +306,7 @@ bool wlm_egl_query_dmabuf_formats(ctx_t * ctx) {
         return false;
     }
 
-    dmabuf_format_t * dmabuf_formats = calloc(num_formats, sizeof *dmabuf_formats);
+    wlm_dmabuf_format_t * dmabuf_formats = calloc(num_formats, sizeof *dmabuf_formats);
     if (dmabuf_formats == NULL) {
         free(egl_drm_formats);
         wlm_log_error("egl::init(): failed to allocate dmabuf format array\n");
@@ -444,7 +444,7 @@ void wlm_egl_resize_viewport(ctx_t * ctx) {
         // wayland doesn't provide this information
         // TODO: figure out how to deal with this without hardcoding output targets
         double output_scale = 1;
-        output_list_node_t * output_node = wlm_mirror_target_get_output_node(ctx->mirror.current_target);
+        wlm_wayland_output_entry_t * output_node = wlm_mirror_target_get_output_node(ctx->mirror.current_target);
         if (output_node != NULL) {
             output_scale = (double)tex_width / output_node->width;
         }

--- a/src/egl.c
+++ b/src/egl.c
@@ -1,3 +1,4 @@
+#include "wlm/mirror/target.h"
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 #include <EGL/egl.h>
@@ -422,13 +423,17 @@ void wlm_egl_resize_viewport(ctx_t * ctx) {
 
     // rotate texture dimensions by output transform
     if (ctx->egl.texture_initialized) {
-        wlm_util_viewport_apply_output_transform(&tex_width, &tex_height, ctx->mirror.current_target->transform);
+        enum wl_output_transform transform = wlm_mirror_target_get_transform(ctx->mirror.current_target);
+        wlm_util_viewport_apply_output_transform(&tex_width, &tex_height, transform);
     }
 
     // clamp texture dimensions to specified region
     region_t output_region;
     region_t clamp_region;
     if (ctx->egl.texture_initialized && ctx->opt.has_region && !ctx->egl.texture_region_aware) {
+        // TODO: handle output regions differently
+        // TODO: allow specifying regions relative to recording target
+
         output_region = (region_t){
             .x = 0, .y = 0,
             .width = tex_width, .height = tex_height
@@ -437,7 +442,12 @@ void wlm_egl_resize_viewport(ctx_t * ctx) {
 
         // HACK: calculate effective output fractional scale
         // wayland doesn't provide this information
-        double output_scale = (double)tex_width / ctx->mirror.current_target->width;
+        // TODO: figure out how to deal with this without hardcoding output targets
+        double output_scale = 1;
+        output_list_node_t * output_node = wlm_mirror_target_get_output_node(ctx->mirror.current_target);
+        if (output_node != NULL) {
+            output_scale = (double)tex_width / output_node->width;
+        }
         wlm_util_region_scale(&clamp_region, output_scale);
         wlm_util_region_clamp(&clamp_region, &output_region);
 
@@ -510,7 +520,8 @@ void wlm_egl_resize_viewport(ctx_t * ctx) {
             wlm_util_mat3_apply_region_transform(&texture_transform, &clamp_region, &output_region);
         }
 
-        wlm_util_mat3_apply_output_transform(&texture_transform, ctx->mirror.current_target->transform);
+        enum wl_output_transform transform = wlm_mirror_target_get_transform(ctx->mirror.current_target);
+        wlm_util_mat3_apply_output_transform(&texture_transform, transform);
         wlm_util_mat3_apply_invert_y(&texture_transform, ctx->mirror.invert_y);
     }
 

--- a/src/egl/dmabuf.c
+++ b/src/egl/dmabuf.c
@@ -44,7 +44,7 @@ static const EGLAttrib modifier_high_attribs[] = {
 };
 _Static_assert(ARRAY_LENGTH(modifier_high_attribs) == MAX_PLANES, "modifier_high_attribs has incorrect length");
 
-bool wlm_egl_dmabuf_import(ctx_t * ctx, dmabuf_t * dmabuf, const wlm_egl_format_t * format, bool invert_y, bool region_aware) {
+bool wlm_egl_dmabuf_import(ctx_t * ctx, wlm_dmabuf_t * dmabuf, const wlm_egl_format_t * format, bool invert_y, bool region_aware) {
     if (dmabuf->planes > MAX_PLANES) {
         wlm_log_error("egl::dmabuf::import(): too many planes, got %zd, can support at most %d\n", dmabuf->planes, MAX_PLANES);
         return false;

--- a/src/mirror.c
+++ b/src/mirror.c
@@ -60,7 +60,7 @@ static const struct wl_callback_listener frame_callback_listener = {
 
 // --- init_mirror ---
 
-static fallback_backend_t auto_fallback_backends[];
+static wlm_fallback_backend_t auto_fallback_backends[];
 void wlm_mirror_init(ctx_t * ctx) {
     // initialize context structure
     ctx->mirror.current_target = NULL;
@@ -78,7 +78,7 @@ void wlm_mirror_init(ctx_t * ctx) {
     // TODO: make wlm_mirror_target_parse implement finding output (or toplevel?) by region
     // TODO: only find and create target in a single place! (other place is opt parse)
     // finding target output
-    output_list_node_t * target_output = NULL;
+    wlm_wayland_output_entry_t * target_output = NULL;
     if (!wlm_opt_find_output(ctx, &target_output, &ctx->mirror.current_region)) {
         wlm_log_error("mirror::init(): failed to find output\n");
         wlm_exit_fail(ctx);
@@ -95,7 +95,7 @@ void wlm_mirror_init(ctx_t * ctx) {
 
 // --- auto backend handler
 
-static fallback_backend_t auto_fallback_backends[] = {
+static wlm_fallback_backend_t auto_fallback_backends[] = {
 #ifdef WITH_GBM
     { "extcopy-dmabuf", wlm_mirror_extcopy_dmabuf_init },
     { "screencopy-dmabuf", wlm_mirror_screencopy_dmabuf_init },
@@ -106,7 +106,7 @@ static fallback_backend_t auto_fallback_backends[] = {
     { NULL, NULL }
 };
 
-static fallback_backend_t auto_screencopy_backends[] = {
+static wlm_fallback_backend_t auto_screencopy_backends[] = {
 #ifdef WITH_GBM
     { "screencopy-dmabuf", wlm_mirror_screencopy_dmabuf_init },
 #endif
@@ -114,7 +114,7 @@ static fallback_backend_t auto_screencopy_backends[] = {
     { NULL, NULL }
 };
 
-static fallback_backend_t auto_extcopy_backends[] = {
+static wlm_fallback_backend_t auto_extcopy_backends[] = {
 #ifdef WITH_GBM
     { "extcopy-dmabuf", wlm_mirror_extcopy_dmabuf_init },
 #endif
@@ -126,7 +126,7 @@ static void auto_backend_fallback(ctx_t * ctx) {
     while (true) {
         // get next backend
         size_t index = ctx->mirror.auto_backend_index;
-        fallback_backend_t * next_backend = &ctx->mirror.fallback_backends[index];
+        wlm_fallback_backend_t * next_backend = &ctx->mirror.fallback_backends[index];
         if (next_backend->name == NULL) {
             wlm_log_error("mirror::auto_backend_fallback(): no working backend found, exiting\n");
             wlm_exit_fail(ctx);
@@ -203,7 +203,7 @@ void wlm_mirror_backend_init(ctx_t * ctx) {
 
 // --- output_removed ---
 
-void wlm_mirror_output_removed(ctx_t * ctx, output_list_node_t * node) {
+void wlm_mirror_output_removed(ctx_t * ctx, wlm_wayland_output_entry_t * node) {
     if (!ctx->mirror.initialized) return;
     if (ctx->mirror.current_target == NULL) return;
     if (wlm_mirror_target_get_output_node(ctx->mirror.current_target) != node) return;
@@ -246,7 +246,7 @@ static int format_title(ctx_t * ctx, char ** dst, char * fmt) {
 
     if (ctx->mirror.initialized && ctx->mirror.current_target != NULL) {
         // TODO: support for other target types
-        output_list_node_t * output_node = wlm_mirror_target_get_output_node(ctx->mirror.current_target);
+        wlm_wayland_output_entry_t * output_node = wlm_mirror_target_get_output_node(ctx->mirror.current_target);
         if (output_node != NULL) {
             target_width = output_node->width;
             target_height = output_node->height;

--- a/src/mirror.c
+++ b/src/mirror.c
@@ -74,11 +74,16 @@ void wlm_mirror_init(ctx_t * ctx) {
 
     ctx->mirror.initialized = true;
 
+    // TODO: use wlm_mirror_target_parse
+    // TODO: make wlm_mirror_target_parse implement finding output (or toplevel?) by region
+    // TODO: only find and create target in a single place! (other place is opt parse)
     // finding target output
-    if (!wlm_opt_find_output(ctx, &ctx->mirror.current_target, &ctx->mirror.current_region)) {
+    output_list_node_t * target_output = NULL;
+    if (!wlm_opt_find_output(ctx, &target_output, &ctx->mirror.current_region)) {
         wlm_log_error("mirror::init(): failed to find output\n");
         wlm_exit_fail(ctx);
     }
+    ctx->mirror.current_target = wlm_mirror_target_create_output(ctx, target_output);
 
     // update window title
     wlm_mirror_update_title(ctx);
@@ -201,7 +206,7 @@ void wlm_mirror_backend_init(ctx_t * ctx) {
 void wlm_mirror_output_removed(ctx_t * ctx, output_list_node_t * node) {
     if (!ctx->mirror.initialized) return;
     if (ctx->mirror.current_target == NULL) return;
-    if (ctx->mirror.current_target != node) return;
+    if (wlm_mirror_target_get_output_node(ctx->mirror.current_target) != node) return;
 
     wlm_log_error("mirror::output_removed(): output disappeared, closing\n");
     wlm_exit_fail(ctx);
@@ -234,9 +239,20 @@ static int format_title(ctx_t * ctx, char ** dst, char * fmt) {
     int y                    = !ctx->mirror.initialized ? 0 : ctx->mirror.current_region.y;
     int width                = !ctx->mirror.initialized ? 0 : ctx->mirror.current_region.width;
     int height               = !ctx->mirror.initialized ? 0 : ctx->mirror.current_region.height;
-    int target_width         = !ctx->mirror.initialized ? 0 : ctx->mirror.current_target == NULL ? 0 : ctx->mirror.current_target->width;
-    int target_height        = !ctx->mirror.initialized ? 0 : ctx->mirror.current_target == NULL ? 0 : ctx->mirror.current_target->height;
-    const char * target_name = !ctx->mirror.initialized ? "" : ctx->mirror.current_target == NULL ? "" : ctx->mirror.current_target->name;
+
+    uint32_t target_width = 0;
+    uint32_t target_height = 0;
+    const char * target_name = "";
+
+    if (ctx->mirror.initialized && ctx->mirror.current_target != NULL) {
+        // TODO: support for other target types
+        output_list_node_t * output_node = wlm_mirror_target_get_output_node(ctx->mirror.current_target);
+        if (output_node != NULL) {
+            target_width = output_node->width;
+            target_height = output_node->height;
+            target_name = output_node->name;
+        }
+    }
 
     specifier_t replacements[] = {
         {"{x}", 'd', {.d = x}},
@@ -331,6 +347,7 @@ void wlm_mirror_cleanup(ctx_t * ctx) {
 
     wlm_log_debug(ctx, "mirror::cleanup(): destroying mirror objects\n");
 
+    if (ctx->mirror.current_target != NULL) wlm_mirror_target_destroy(ctx->mirror.current_target);
     if (ctx->mirror.backend != NULL) ctx->mirror.backend->do_cleanup(ctx);
     if (ctx->mirror.frame_callback != NULL) wl_callback_destroy(ctx->mirror.frame_callback);
 

--- a/src/mirror/export-dmabuf.c
+++ b/src/mirror/export-dmabuf.c
@@ -248,9 +248,17 @@ static void do_capture(ctx_t * ctx) {
         backend->state = STATE_WAIT_FRAME;
         backend->processed_objects = 0;
 
+        // check if target is supported
+        output_list_node_t * output_node = wlm_mirror_target_get_output_node(ctx->mirror.current_target);
+        if (output_node == NULL) {
+            wlm_log_error("mirror-export-dmabuf::do_capture(): capture target not supported by this backend\n");
+            wlm_mirror_backend_fail(ctx);
+            return;
+        }
+
         // create wlr_dmabuf_export_frame
         backend->dmabuf_frame = zwlr_export_dmabuf_manager_v1_capture_output(
-            ctx->wl.dmabuf_manager, ctx->opt.show_cursor, ctx->mirror.current_target->output
+            ctx->wl.dmabuf_manager, ctx->opt.show_cursor, output_node->output
         );
         if (backend->dmabuf_frame == NULL) {
             wlm_log_error("mirror-export-dmabuf::do_capture(): failed to create wlr_dmabuf_export_frame\n");

--- a/src/mirror/export-dmabuf.c
+++ b/src/mirror/export-dmabuf.c
@@ -249,7 +249,7 @@ static void do_capture(ctx_t * ctx) {
         backend->processed_objects = 0;
 
         // check if target is supported
-        output_list_node_t * output_node = wlm_mirror_target_get_output_node(ctx->mirror.current_target);
+        wlm_wayland_output_entry_t * output_node = wlm_mirror_target_get_output_node(ctx->mirror.current_target);
         if (output_node == NULL) {
             wlm_log_error("mirror-export-dmabuf::do_capture(): capture target not supported by this backend\n");
             wlm_mirror_backend_fail(ctx);
@@ -327,5 +327,5 @@ void wlm_mirror_export_dmabuf_init(ctx_t * ctx) {
     backend->processed_objects = 0;
 
     // set backend object as current backend
-    ctx->mirror.backend = (mirror_backend_t *)backend;
+    ctx->mirror.backend = (wlm_mirror_backend_t *)backend;
 }

--- a/src/mirror/extcopy.c
+++ b/src/mirror/extcopy.c
@@ -284,7 +284,7 @@ static void on_capture_frame_ready(void * data, struct ext_image_copy_capture_fr
             return;
         }
 
-        dmabuf_t * dmabuf = wlm_wayland_dmabuf_get_raw_buffer(ctx);
+        wlm_dmabuf_t * dmabuf = wlm_wayland_dmabuf_get_raw_buffer(ctx);
         if (dmabuf == NULL) {
             wlm_log_error("mirror-extcopy::on_capture_frame_ready(): DMA-BUF disappeared\n");
             backend_cancel(ctx, backend);
@@ -457,7 +457,7 @@ static void wlm_mirror_extcopy_init(ctx_t * ctx, bool use_dmabuf) {
     backend->state = STATE_INIT;
 
     // set backend object as current backend
-    ctx->mirror.backend = (mirror_backend_t *)backend;
+    ctx->mirror.backend = (wlm_mirror_backend_t *)backend;
 
     if (!use_dmabuf) {
         // create shm pool

--- a/src/mirror/screencopy.c
+++ b/src/mirror/screencopy.c
@@ -281,18 +281,26 @@ static void do_capture(ctx_t * ctx) {
         backend->frame_flags = 0;
         backend->state = STATE_WAIT_BUFFER;
 
+        // check if target is supported
+        output_list_node_t * output_node = wlm_mirror_target_get_output_node(ctx->mirror.current_target);
+        if (output_node == NULL) {
+            wlm_log_error("mirror-screencopy::do_capture(): capture target not supported by this backend\n");
+            wlm_mirror_backend_fail(ctx);
+            return;
+        }
+
         // create screencopy_frame
         if (ctx->opt.has_region) {
             backend->screencopy_frame = zwlr_screencopy_manager_v1_capture_output_region(
-                ctx->wl.screencopy_manager, ctx->opt.show_cursor, ctx->mirror.current_target->output,
-                ctx->mirror.current_target->x + ctx->mirror.current_region.x,
-                ctx->mirror.current_target->y + ctx->mirror.current_region.y,
+                ctx->wl.screencopy_manager, ctx->opt.show_cursor, output_node->output,
+                output_node->x + ctx->mirror.current_region.x,
+                output_node->y + ctx->mirror.current_region.y,
                 ctx->mirror.current_region.width,
                 ctx->mirror.current_region.height
             );
         } else {
             backend->screencopy_frame = zwlr_screencopy_manager_v1_capture_output(
-                ctx->wl.screencopy_manager, ctx->opt.show_cursor, ctx->mirror.current_target->output
+                ctx->wl.screencopy_manager, ctx->opt.show_cursor, output_node->output
             );
         }
         if (backend->screencopy_frame == NULL) {

--- a/src/mirror/screencopy.c
+++ b/src/mirror/screencopy.c
@@ -282,7 +282,7 @@ static void do_capture(ctx_t * ctx) {
         backend->state = STATE_WAIT_BUFFER;
 
         // check if target is supported
-        output_list_node_t * output_node = wlm_mirror_target_get_output_node(ctx->mirror.current_target);
+        wlm_wayland_output_entry_t * output_node = wlm_mirror_target_get_output_node(ctx->mirror.current_target);
         if (output_node == NULL) {
             wlm_log_error("mirror-screencopy::do_capture(): capture target not supported by this backend\n");
             wlm_mirror_backend_fail(ctx);
@@ -382,7 +382,7 @@ static void wlm_mirror_screencopy_init(ctx_t * ctx, bool use_dmabuf) {
     backend->frame_flags = 0;
 
     // set backend object as current backend
-    ctx->mirror.backend = (mirror_backend_t *)backend;
+    ctx->mirror.backend = (wlm_mirror_backend_t *)backend;
 
     if (use_dmabuf) {
         backend->state = STATE_WAIT_DMABUF_DEVICE;

--- a/src/mirror/target.c
+++ b/src/mirror/target.c
@@ -17,7 +17,7 @@ static wlm_mirror_target_t * create_null_target(ctx_t * ctx) {
     return target;
 }
 
-static wlm_mirror_target_t * create_output_target(ctx_t * ctx, output_list_node_t * output_node) {
+static wlm_mirror_target_t * create_output_target(ctx_t * ctx, wlm_wayland_output_entry_t * output_node) {
     wlm_mirror_target_output_t * output_target = calloc(1, sizeof *output_target);
     output_target->header.type = WLM_MIRROR_TARGET_TYPE_OUTPUT;
     output_target->header.source = NULL;
@@ -80,13 +80,13 @@ wlm_mirror_target_t * wlm_mirror_target_parse(ctx_t * ctx, const char * target_s
 }
 
 // TODO: remove this
-wlm_mirror_target_t * wlm_mirror_target_create_output(ctx_t * ctx, output_list_node_t * output_node) {
+wlm_mirror_target_t * wlm_mirror_target_create_output(ctx_t * ctx, wlm_wayland_output_entry_t * output_node) {
     return create_output_target(ctx, output_node);
 }
 
 wlm_mirror_target_t * wlm_mirror_target_find_output(ctx_t * ctx, const char * name) {
     // try to match output by name
-    output_list_node_t * output_node = NULL;
+    wlm_wayland_output_entry_t * output_node = NULL;
     if (!wlm_wayland_find_output(ctx, name, &output_node)) {
         return NULL;
     }
@@ -129,7 +129,7 @@ wlm_mirror_target_t * wlm_mirror_target_find_toplevel(ctx_t * ctx, const char * 
     (void)create_toplevel_target;
 }
 
-output_list_node_t * wlm_mirror_target_get_output_node(wlm_mirror_target_t * target) {
+wlm_wayland_output_entry_t * wlm_mirror_target_get_output_node(wlm_mirror_target_t * target) {
     if (target == NULL) {
         return NULL;
     }

--- a/src/mirror/target.c
+++ b/src/mirror/target.c
@@ -1,0 +1,171 @@
+#include <wayland-client-protocol.h>
+#include <wlm/context.h>
+#include <wlm/wayland.h>
+#include <wlm/mirror/target.h>
+#include <wlm/proto/ext-image-capture-source-v1.h>
+#include <stdlib.h>
+#include <string.h>
+
+// --- static helper functions
+
+static wlm_mirror_target_t * create_null_target(ctx_t * ctx) {
+    wlm_mirror_target_t * target = calloc(1, sizeof *target);
+    target->type = WLM_MIRROR_TARGET_TYPE_NULL;
+    target->source = NULL;
+
+    (void)ctx;
+    return target;
+}
+
+static wlm_mirror_target_t * create_output_target(ctx_t * ctx, output_list_node_t * output_node) {
+    wlm_mirror_target_output_t * output_target = calloc(1, sizeof *output_target);
+    output_target->header.type = WLM_MIRROR_TARGET_TYPE_OUTPUT;
+    output_target->header.source = NULL;
+    output_target->header.transform = output_node->transform;
+    output_target->output = output_node;
+
+    if (ctx->wl.output_capture_source_manager != NULL) {
+        output_target->header.source = ext_output_image_capture_source_manager_v1_create_source(ctx->wl.output_capture_source_manager, output_node->output);
+    }
+
+    return (wlm_mirror_target_t *)output_target;
+}
+
+static wlm_mirror_target_t * create_toplevel_target(ctx_t * ctx, struct ext_foreign_toplevel_handle_v1 * toplevel) {
+    wlm_mirror_target_toplevel_t * toplevel_target = calloc(1, sizeof *toplevel_target);
+    toplevel_target->header.type = WLM_MIRROR_TARGET_TYPE_OUTPUT;
+    toplevel_target->header.source = NULL;
+    toplevel_target->header.transform = WL_OUTPUT_TRANSFORM_NORMAL;
+    toplevel_target->toplevel = toplevel;
+
+    if (ctx->wl.toplevel_capture_source_manager != NULL) {
+        toplevel_target->header.source = ext_foreign_toplevel_image_capture_source_manager_v1_create_source(ctx->wl.toplevel_capture_source_manager, toplevel);
+    }
+
+    return (wlm_mirror_target_t *)toplevel_target;
+}
+
+// --- public functions ---
+
+wlm_mirror_target_t * wlm_mirror_target_parse(ctx_t * ctx, const char * target_str) {
+    // find prefix
+    const char * prefix_separator = strchr(target_str, ':');
+
+    // no prefix
+    if (prefix_separator == NULL) {
+        // match output using the whole target string
+        // fallback to legacy wl-mirror behaviour
+        return wlm_mirror_target_find_output(ctx, target_str);
+    }
+
+    // find prefix length and pointer to target name after prefix
+    int prefix_len = prefix_separator - target_str;
+    const char * prefix_str = target_str;
+    const char * target_name_str = prefix_separator + 1;
+
+    // match different prefix kinds
+    if (strncmp(prefix_str, "null:", prefix_len) == 0 && strcmp(target_name_str, "") == 0) {
+        return create_null_target(ctx);
+    } else if (strncmp(prefix_str, "output:", prefix_len) == 0) {
+        // match output
+        return wlm_mirror_target_find_output(ctx, target_name_str);
+    } else if (strncmp(prefix_str, "toplevel:", prefix_len) == 0) {
+        // match toplevel
+        return wlm_mirror_target_find_toplevel(ctx, target_name_str);
+    } else {
+        // unknown prefix
+        wlm_log_error("mirror-target::parse(): invalid target prefix '%.*s'\n", prefix_len, prefix_str);
+        return NULL;
+    }
+}
+
+// TODO: remove this
+wlm_mirror_target_t * wlm_mirror_target_create_output(ctx_t * ctx, output_list_node_t * output_node) {
+    return create_output_target(ctx, output_node);
+}
+
+wlm_mirror_target_t * wlm_mirror_target_find_output(ctx_t * ctx, const char * name) {
+    // try to match output by name
+    output_list_node_t * output_node = NULL;
+    if (!wlm_wayland_find_output(ctx, name, &output_node)) {
+        return NULL;
+    }
+
+    // kanshi syntax:
+    //   match when:
+    //     name == '*' or
+    //     name == output name or
+    //     name == '{output make} {output model} {output serial}'
+    //
+    // sway syntax
+    //   match when
+    //     name == '*' or
+    //     name == output name or
+    //     name == '{output make} {output model} {output serial}'
+    //
+    // wl-mirror syntax
+    //   match when
+    //     name == output name or
+    //     name == '{output make} {output model} {output serial}' or
+
+    // TODO: double-check that this syntax is ok
+
+    return create_output_target(ctx, output_node);
+}
+
+wlm_mirror_target_t * wlm_mirror_target_find_toplevel(ctx_t * ctx, const char * identifier) {
+    wlm_log_warn("mirror-target::find_toplevel(): finding target toplevel not yet implemented\n");
+
+    return NULL;
+
+    // wl-mirror syntax
+    //   match when
+    //     identifier == toplevel identifier or
+    //     identifier == '{toplevel app_id}' or
+    //     identifier == '{toplevel app_id} {toplevel title}'
+
+    (void)ctx;
+    (void)identifier;
+    (void)create_toplevel_target;
+}
+
+output_list_node_t * wlm_mirror_target_get_output_node(wlm_mirror_target_t * target) {
+    if (target == NULL) {
+        return NULL;
+    }
+
+    if (target->type != WLM_MIRROR_TARGET_TYPE_OUTPUT) {
+        return NULL;
+    }
+
+    wlm_mirror_target_output_t * output_target = (wlm_mirror_target_output_t *)target;
+    return output_target->output;
+}
+
+struct ext_image_capture_source_v1 * wlm_mirror_target_get_capture_source(wlm_mirror_target_t * target) {
+    if (target == NULL) {
+        return NULL;
+    }
+
+    return target->source;
+}
+
+enum wl_output_transform wlm_mirror_target_get_transform(wlm_mirror_target_t * target) {
+    if (target == NULL) {
+        return WL_OUTPUT_TRANSFORM_NORMAL;
+    }
+
+    return target->transform;
+}
+
+void wlm_mirror_target_destroy(wlm_mirror_target_t * target) {
+    if (target == NULL) {
+        return;
+    }
+
+    if (target->source != NULL) {
+        ext_image_capture_source_v1_destroy(target->source);
+    }
+
+    free(target);
+}

--- a/src/options.c
+++ b/src/options.c
@@ -288,9 +288,9 @@ bool wlm_opt_parse_region(region_t * region, char ** output, const char * region
     return true;
 }
 
-bool wlm_opt_find_output(ctx_t * ctx, output_list_node_t ** output_handle, region_t * region_handle) {
+bool wlm_opt_find_output(ctx_t * ctx, wlm_wayland_output_entry_t ** output_handle, region_t * region_handle) {
     char * output_name = ctx->opt.output;
-    output_list_node_t * local_output_handle = NULL;
+    wlm_wayland_output_entry_t * local_output_handle = NULL;
     region_t local_region = (region_t){ .x = 0, .y = 0, .width = 0, .height = 0 };
 
     if (ctx->opt.output != NULL) {
@@ -298,7 +298,7 @@ bool wlm_opt_find_output(ctx_t * ctx, output_list_node_t ** output_handle, regio
         wlm_wayland_find_output(ctx, ctx->opt.output, &local_output_handle);
     } else if (ctx->opt.has_region) {
         wlm_log_debug(ctx, "options::find_output(): searching for output by region\n");
-        output_list_node_t * cur = ctx->wl.outputs;
+        wlm_wayland_output_entry_t * cur = ctx->wl.outputs;
         while (cur != NULL) {
             region_t output_region = {
                 .x = cur->x, .y = cur->y,
@@ -651,7 +651,7 @@ void wlm_opt_parse(ctx_t * ctx, int argc, char ** argv) {
         wlm_wayland_window_unset_fullscreen(ctx);
     }
 
-    output_list_node_t * target_output = NULL;
+    wlm_wayland_output_entry_t * target_output = NULL;
     region_t target_region = (region_t){ .x = 0, .y = 0, .width = 0, .height = 0 };
     if (!is_cli_args && wlm_opt_find_output(ctx, &target_output, &target_region)) {
         // TODO: only find and create target in a single place! (other place is mirror init)

--- a/src/options.c
+++ b/src/options.c
@@ -295,16 +295,7 @@ bool wlm_opt_find_output(ctx_t * ctx, output_list_node_t ** output_handle, regio
 
     if (ctx->opt.output != NULL) {
         wlm_log_debug(ctx, "options::find_output(): searching for output by name\n");
-        output_list_node_t * cur = ctx->wl.outputs;
-        while (cur != NULL) {
-            if (cur->name != NULL && strcmp(cur->name, ctx->opt.output) == 0) {
-                local_output_handle = cur;
-                output_name = cur->name;
-                break;
-            }
-
-            cur = cur->next;
-        }
+        wlm_wayland_find_output(ctx, ctx->opt.output, &local_output_handle);
     } else if (ctx->opt.has_region) {
         wlm_log_debug(ctx, "options::find_output(): searching for output by region\n");
         output_list_node_t * cur = ctx->wl.outputs;
@@ -663,7 +654,9 @@ void wlm_opt_parse(ctx_t * ctx, int argc, char ** argv) {
     output_list_node_t * target_output = NULL;
     region_t target_region = (region_t){ .x = 0, .y = 0, .width = 0, .height = 0 };
     if (!is_cli_args && wlm_opt_find_output(ctx, &target_output, &target_region)) {
-        ctx->mirror.current_target = target_output;
+        // TODO: only find and create target in a single place! (other place is mirror init)
+        wlm_mirror_target_destroy(ctx->mirror.current_target);
+        ctx->mirror.current_target = wlm_mirror_target_create_output(ctx, target_output);
         ctx->mirror.current_region = target_region;
     }
 

--- a/src/wayland.c
+++ b/src/wayland.c
@@ -10,7 +10,7 @@ static void on_output_geometry(
     int32_t x, int32_t y, int32_t physical_width, int32_t physical_height,
     int32_t subpixel, const char * make, const char * model, int32_t transform
 ) {
-    output_list_node_t * node = (output_list_node_t *)data;
+    wlm_wayland_output_entry_t * node = (wlm_wayland_output_entry_t *)data;
     ctx_t * ctx = node->ctx;
 
     // update make only if changed
@@ -106,7 +106,7 @@ static void on_output_scale(
     void * data, struct wl_output * output,
     int32_t scale
 ) {
-    output_list_node_t * node = (output_list_node_t *)data;
+    wlm_wayland_output_entry_t * node = (wlm_wayland_output_entry_t *)data;
     ctx_t * ctx = node->ctx;
 
     // update scale only if changed
@@ -142,7 +142,7 @@ static void on_xdg_output_description(
     void * data, struct zxdg_output_v1 * xdg_output,
     const char * description
 ) {
-    output_list_node_t * node = (output_list_node_t *)data;
+    wlm_wayland_output_entry_t * node = (wlm_wayland_output_entry_t *)data;
     ctx_t * ctx = node->ctx;
 
     // update description only if changed
@@ -159,7 +159,7 @@ static void on_xdg_output_logical_position(
     void * data, struct zxdg_output_v1 * xdg_output,
     int32_t x, int32_t y
 ) {
-    output_list_node_t * node = (output_list_node_t *)data;
+    wlm_wayland_output_entry_t * node = (wlm_wayland_output_entry_t *)data;
     ctx_t * ctx = node->ctx;
 
     // update position only if changed
@@ -177,7 +177,7 @@ static void on_xdg_output_logical_size(
     void * data, struct zxdg_output_v1 * xdg_output,
     int32_t width, int32_t height
 ) {
-    output_list_node_t * node = (output_list_node_t *)data;
+    wlm_wayland_output_entry_t * node = (wlm_wayland_output_entry_t *)data;
     ctx_t * ctx = node->ctx;
 
     // update size only if changed
@@ -195,7 +195,7 @@ static void on_xdg_output_name(
     void * data, struct zxdg_output_v1 * xdg_output,
     const char * name
 ) {
-    output_list_node_t * node = (output_list_node_t *)data;
+    wlm_wayland_output_entry_t * node = (wlm_wayland_output_entry_t *)data;
     ctx_t * ctx = node->ctx;
 
     // update name only if changed
@@ -380,7 +380,7 @@ static void on_registry_add(
         ctx->wl.linux_dmabuf_id = id;
     } else if (strcmp(interface, wl_output_interface.name) == 0) {
         // allocate output node
-        output_list_node_t * node = malloc(sizeof (output_list_node_t));
+        wlm_wayland_output_entry_t * node = malloc(sizeof (wlm_wayland_output_entry_t));
         if (node == NULL) {
             wlm_log_error("wayland::on_registry_add(): failed to allocate output node\n");
             wlm_exit_fail(ctx);
@@ -439,7 +439,7 @@ static void on_registry_add(
         zxdg_output_v1_add_listener(node->xdg_output, &xdg_output_listener, (void *)node);
     } else if (strcmp(interface, wl_seat_interface.name) == 0) {
         // allocate seat node
-        seat_list_node_t * node = malloc(sizeof (seat_list_node_t));
+        wlm_wayland_seat_entry_t * node = malloc(sizeof (wlm_wayland_seat_entry_t));
         if (node == NULL) {
             wlm_log_error("wayland::on_registry_add(): failed to allocate seat node\n");
             wlm_exit_fail(ctx);
@@ -505,9 +505,9 @@ static void on_registry_remove(
         wlm_exit_fail(ctx);
     } else {
         {
-            output_list_node_t ** link = &ctx->wl.outputs;
-            output_list_node_t * cur = ctx->wl.outputs;
-            output_list_node_t * prev = NULL;
+            wlm_wayland_output_entry_t ** link = &ctx->wl.outputs;
+            wlm_wayland_output_entry_t * cur = ctx->wl.outputs;
+            wlm_wayland_output_entry_t * prev = NULL;
             while (cur != NULL) {
                 if (id == cur->output_id) {
                     wlm_log_debug(ctx, "wayland::on_registry_remove(): output %s removed (id = %d)\n", cur->name, id);
@@ -542,9 +542,9 @@ static void on_registry_remove(
         // output not found
         // id must have been a seat
         {
-            seat_list_node_t ** link = &ctx->wl.seats;
-            seat_list_node_t * cur = ctx->wl.seats;
-            seat_list_node_t * prev = NULL;
+            wlm_wayland_seat_entry_t ** link = &ctx->wl.seats;
+            wlm_wayland_seat_entry_t * cur = ctx->wl.seats;
+            wlm_wayland_seat_entry_t * prev = NULL;
             while (cur != NULL) {
                 if (id == cur->seat_id) {
                     wlm_log_debug(ctx, "wayland::on_registry_remove(): seat removed (id = %d)\n", id);
@@ -598,8 +598,8 @@ static void on_surface_enter(
     ctx_t * ctx = (ctx_t *)data;
 
     // find output list node for the entered output
-    output_list_node_t * node = NULL;
-    output_list_node_t * cur = ctx->wl.outputs;
+    wlm_wayland_output_entry_t * node = NULL;
+    wlm_wayland_output_entry_t * cur = ctx->wl.outputs;
     while (cur != NULL) {
         if (cur->output == output) {
             node = cur;
@@ -911,7 +911,7 @@ static const struct wp_fractional_scale_v1_listener fractional_scale_listener = 
 
 // --- find_output ---
 
-static bool match_output(output_list_node_t * node, const char * name) {
+static bool match_output(wlm_wayland_output_entry_t * node, const char * name) {
     // check if name is equal
     if (node->name != NULL && strcmp(node->name, name) == 0) {
         // matched output name (e.g. 'eDP-1')
@@ -991,9 +991,9 @@ static bool match_output(output_list_node_t * node, const char * name) {
     return true;
 }
 
-bool wlm_wayland_find_output(ctx_t * ctx, const char * output_name, output_list_node_t ** output) {
+bool wlm_wayland_find_output(ctx_t * ctx, const char * output_name, wlm_wayland_output_entry_t ** output) {
     bool found = false;
-    output_list_node_t * cur = ctx->wl.outputs;
+    wlm_wayland_output_entry_t * cur = ctx->wl.outputs;
     while (cur != NULL) {
         if (match_output(cur, output_name)) {
             break;
@@ -1273,7 +1273,7 @@ void wlm_wayland_window_set_title(ctx_t * ctx, const char * title) {
 // --- set_window_fullscreen ---
 
 void wlm_wayland_window_set_fullscreen(ctx_t * ctx) {
-    output_list_node_t * output_node = NULL;
+    wlm_wayland_output_entry_t * output_node = NULL;
     if (ctx->opt.fullscreen_output == NULL) {
         output_node = ctx->wl.current_output;
     } else if (!wlm_wayland_find_output(ctx, ctx->opt.fullscreen_output, &output_node)) {
@@ -1331,8 +1331,8 @@ void wlm_wayland_cleanup(ctx_t *ctx) {
 
     {
         // free every output in output list
-        output_list_node_t * cur = ctx->wl.outputs;
-        output_list_node_t * prev = NULL;
+        wlm_wayland_output_entry_t * cur = ctx->wl.outputs;
+        wlm_wayland_output_entry_t * prev = NULL;
         while (cur != NULL) {
             prev = cur;
             cur = cur->next;
@@ -1351,8 +1351,8 @@ void wlm_wayland_cleanup(ctx_t *ctx) {
 
     {
         // free every seat in seat list
-        seat_list_node_t * cur = ctx->wl.seats;
-        seat_list_node_t * prev = NULL;
+        wlm_wayland_seat_entry_t * cur = ctx->wl.seats;
+        wlm_wayland_seat_entry_t * prev = NULL;
         while (cur != NULL) {
             prev = cur;
             cur = cur->next;

--- a/src/wayland/dmabuf.c
+++ b/src/wayland/dmabuf.c
@@ -352,7 +352,7 @@ struct wl_buffer * wlm_wayland_dmabuf_get_buffer(ctx_t * ctx) {
 
 // --- wlm_wayland_dmabuf_get_raw_buffer ---
 
-dmabuf_t * wlm_wayland_dmabuf_get_raw_buffer(ctx_t * ctx) {
+wlm_dmabuf_t * wlm_wayland_dmabuf_get_raw_buffer(ctx_t * ctx) {
     if (ctx->wl.dmabuf.buffer == NULL) return NULL;
     return &ctx->wl.dmabuf.raw_buffer;
 }


### PR DESCRIPTION
WIP PR for implementing non-wl_output target support and toplevel capture, among other things.

Related Issues:

- Different output name format, aka make/model matching (#58)
- Toplevel Capture (#61)

Current State:

- [ ] `mirror/target.c` generic mirror target type
  - [X] Output Targets
    - output name matching on make/model is partially implemented (wlr output management protocol not used yet, so doesn't work on wlroots since it advertises "Unknown Unknown" for every output in wl_output)
  - [ ] Toplevel Targets
- [ ] `options.c` changes:
  - [ ] Refactor output and region finding code (potentially move to `mirror/target.c`)
- [ ] `wayland.c` changes:
  - [ ] Refactor `output_list_node_t` handling in `wayland.c`
  - [ ] Add toplevel list handling to `wayland.c`
- [ ] `egl.c` changes
  - [ ] Remove wl_output specific hacks